### PR TITLE
Add kernel7.img & kernel7_emergency.img raspberrypi-bootloader pre & postinst

### DIFF
--- a/debian/raspberrypi-bootloader.postinst
+++ b/debian/raspberrypi-bootloader.postinst
@@ -1,6 +1,6 @@
 #!/bin/sh -e
-FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img
-  kernel_cutdown.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
+FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel7.img
+  kernel_cutdown.img kernel_emergency.img kernel7_emergency.img start.elf start_cd.elf start_x.elf"
 
 printf "Memory split is now set in /boot/config.txt.\n"
 printf "You may want to use raspi-config to set it\n"

--- a/debian/raspberrypi-bootloader.preinst
+++ b/debian/raspberrypi-bootloader.preinst
@@ -1,6 +1,6 @@
 #!/bin/sh -e
-FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img
-  kernel_cutdown.img kernel_emergency.img start.elf start_cd.elf start_x.elf"
+FILES="bootcode.bin fixup.dat fixup_cd.dat fixup_x.dat kernel.img kernel7.img
+  kernel_cutdown.img kernel_emergency.img kernel7_emergency.img start.elf start_cd.elf start_x.elf"
 
 # dpkg-divert will error out otherwise
 mkdir -p /usr/share/rpikernelhack


### PR DESCRIPTION
`raspberrypi-bootloader.preinst` & `raspberrypi-bootloader.postinst` were both missing `kernel7.img`, so I added that to both files to support RasPi v2 kernels. I also added `kernel7_emergency.img` to allow for backups of RasPi v2 kernels.

A separate question: Is this the source of the debhelper scripts that build the official `.deb` packages for raspberrypi-bootloader, libraspberrypi0, libraspberrypi-dev, libraspberrypi-bin, & libraspberrypi-doc? We've been looking for the official debian build scripts for use with [this branch of Adafruit's Kernel-o-Matic](https://github.com/adafruit/Adafruit-Pi-Kernel-o-Matic/pull/7), and this repo seems to match the official packages, but we weren't sure since it is not hosted under the [raspberrypi GitHub org](https://github.com/raspberrypi).
